### PR TITLE
Use latest inky

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "chokidar": "^1.4.2",
-    "inky": "1.0.0-rc.1",
+    "inky": "^1.3.0",
     "meow": "^3.7.0",
     "multiline": "^1.0.2"
   },


### PR DESCRIPTION
The previous inky didn't have support for tags like wrapper and probably more stuff.
Latest inky works fine for me but probably needs some testing.

The version I specified looks the major version but not the minor version (semver) perhaps you want to release one version of inky-cli per inky minor version but that requires a lot more work.
